### PR TITLE
ci: cache Gradle, harden permissions, fix test triggers

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Generate API docs
         run: ./gradlew :dokkaGeneratePublicationHtml --console=plain
       - name: Upload Pages artifact

--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -5,11 +5,12 @@ on:
     # We'll run this workflow when a new GitHub release is created
     types: [released]
 
+permissions:
+  contents: read
 
 jobs:
   test:
     uses: ./.github/workflows/test.yml
-    secrets: inherit
 
   publish:
     needs: test
@@ -24,8 +25,12 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-        # Runs upload, and then closes & releases the repository
+        # Uploads & stages the release on Central Portal. The final "Publish"
+        # step is manual there, because build.gradle.kts sets
+        # publishToMavenCentral(automaticRelease = false).
       - name: Publish to MavenCentral
         run: ./gradlew publishToMavenCentral
         env:
@@ -33,4 +38,3 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          SNAPSHOT: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,16 @@ name: Test
 
 on:
   push:
-    branches-ignore: [master]
+    branches: [master]
+  pull_request:
   workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -27,5 +35,7 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Test
         run: ./gradlew ${{ matrix.tasks }} --console=plain


### PR DESCRIPTION
## Summary

Reviewed the CI/CD configuration and applied the safe, high-value fixes. Scoped to the three workflow files only.

### Gradle caching
Add `gradle/actions/setup-gradle@v4` to **all three** workflows (`test`, `publishRelease`, `docs`). Previously every run re-downloaded the Gradle distribution and all dependencies from scratch.

### `test.yml`
- Trigger on `pull_request` + `push: branches: [master]` (was `push: branches-ignore: [master]`). This covers PRs from forks — a fork push never triggered the old setup — and verifies `master` after merge, without duplicate runs.
- Add least-privilege `permissions: contents: read`.
- Add `concurrency` that cancels superseded runs **only for PRs** (never cancels `master` pushes or release publishing).

### `publishRelease.yml`
- Drop unused `secrets: inherit` — the reused `test.yml` consumes no secrets.
- Remove the dead `SNAPSHOT: false` env var. `build.gradle.kts` reads the `snapshot` **Gradle project property**, which a plain `SNAPSHOT` env var does not set (that would require `ORG_GRADLE_PROJECT_snapshot`). Release versioning is unchanged — it was already non-snapshot by default.
- Add `permissions: contents: read`.
- Fix the misleading comment: `publishToMavenCentral` only **uploads/stages** on the Central Portal; the final "Publish" is manual because `build.gradle.kts` sets `automaticRelease = false`.

### `docs.yml`
- Add Gradle caching (only change; permissions/concurrency were already correct).

## Not included (follow-ups)
- `kover` is configured in the build but no workflow runs it — currently dead. Wire up `koverXmlReport` (e.g. Codecov) or drop the plugin.
- Published version is hardcoded in `build.gradle.kts` rather than derived from the release tag.

## Test plan
- All three workflow YAML files validated locally.
- This PR run exercises the new caching + `pull_request` trigger on `test.yml`.
